### PR TITLE
nginx: Enable H2C

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,8 +47,8 @@ http {
   open_file_cache_min_uses 2;
 
   server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
+    listen 80 default_server http2;
+    listen [::]:80 default_server http2;
     server_name abhyudaya.dev;
 
     root /usr/share/nginx/html;


### PR DESCRIPTION
Cloud run now supports HTTP/2 in beta: https://cloud.google.com/blog/products/serverless/cloud-run-gets-websockets-http-2-and-grpc-bidirectional-streams
See https://stackoverflow.com/questions/34108188/how-to-enable-h2c-in-nginx